### PR TITLE
Super8 - trivial defect 8

### DIFF
--- a/app/views/effort_log_mailer/midweek_warning.text.plain.erb
+++ b/app/views/effort_log_mailer/midweek_warning.text.plain.erb
@@ -2,7 +2,7 @@ To <%= @user.human_name %>,
 
 This is a friendly reminder that you have not created an effort log or logged effort for this week.
 
-href="http://rails.sv.cmu.edu/effort_logs
+href=http://rails.sv.cmu.edu/effort_logs
 
 Patrolling the campus,
 


### PR DESCRIPTION
Fixes the following bug:

Extra quote in plain text mail message
