### PR TITLE
Team Super8 - Trivial defect 12

### DIFF
--- a/app/controllers/effort_logs_controller.rb
+++ b/app/controllers/effort_logs_controller.rb
@@ -269,7 +269,11 @@ class EffortLogsController < ApplicationController
     @effort_log = EffortLog.find(params[:id])
 
 #    if @effort_log.week_number != Date.today.cweek
-    if !@effort_log.editable(current_user)          
+    if !@effort_log.has_permission_to_edit(current_user)
+      flash[:error] = 'You do not have permission to edit the effort log.'
+      redirect_to(effort_logs_url) and return
+    end
+    if !@effort_log.has_permission_to_edit_period(current_user)
       flash[:error] = 'You are unable to update effort logs from the past.'
       redirect_to(effort_logs_url) and return
     end
@@ -306,7 +310,11 @@ class EffortLogsController < ApplicationController
     params[:effort_log][:existing_effort_log_line_item_attributes] ||= {}
     
     @effort_log = EffortLog.find(params[:id])
-    if !@effort_log.editable(current_user)        
+    if !@effort_log.has_permission_to_edit(current_user)
+      flash[:error] = 'You do not have permission to edit the effort log.'
+      redirect_to(effort_logs_url) and return
+    end
+    if !@effort_log.has_permission_to_edit_period(current_user)
       flash[:error] = 'You are unable to update effort logs from the past.'
       redirect_to(effort_logs_url) and return
     end

--- a/app/models/effort_log.rb
+++ b/app/models/effort_log.rb
@@ -9,15 +9,29 @@ class EffortLog < ActiveRecord::Base
   before_save :determine_total_effort
 
 
-  def editable(current_user)
+  def has_permission_to_edit(current_user)
     if (current_user && current_user.is_admin?)
-      return true 
+      return true
     end
-    if (current_user && current_user.id != person_id) 
-      return false
+    if (current_user && current_user.id == person_id)
+      return true
     end
-    if (Date.today >= Date.commercial(self.year, self.week_number, 1) && Date.today <= (Date.commercial(self.year, self.week_number, 7) + 1.day)) 
+    return false
+  end
+
+  def has_permission_to_edit_period(current_user)
+    if (current_user && current_user.is_admin?)
+      return true
+    end
+    if (Date.today >= Date.commercial(self.year, self.week_number, 1) && Date.today <= (Date.commercial(self.year, self.week_number, 7) + 1.day))
        return true
+    end
+    return false
+  end
+
+  def editable(current_user)
+    if(has_permission_to_edit(current_user) || has_permission_to_edit_period(current_user))
+      return true 
     end
     return false    
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -76,16 +76,19 @@ faculty_frank:
   crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("benrocks" + salt) %>
   persistence_token: 6cde0674657a8a313ce952df979de2830309aa4c11ca65805dd00bfdc65dbcc2f5e36718660a1d2e68c1a08c276d996763985d2f06fd3d076eb7bc4d97b1e317
 
-#student_john:
-#  login:  john
-#  email:  john@andrew.cmu.edu
-#  is_student: true
-#  is_staff: false
-#  is_teacher: false
-#  is_admin: false
-#  is_alumnus: false
-#  first_name: John
-#  last_name: Student
-#  human_name: John Student
-#  image_uri: images/mascot.jpg
+student_john:
+  login:  john
+  email:  john@andrew.cmu.edu
+  is_student: true
+  is_staff: false
+  is_teacher: false
+  is_admin: false
+  is_alumnus: false
+  first_name: John
+  last_name: Student
+  human_name: John Student
+  image_uri:                 images/mascot.jpg
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("benrocks" + salt) %>
+  persistence_token: 6cde0674657a8a313ce952df979de2830309aa4c11ca65805dd00bfdc65dbcc2f5e36718660a1d2e68c1a08c276d996763985d2f06fd3d076eb7bc4d97b1e317
 

--- a/test/functional/effort_logs_controller_test.rb
+++ b/test/functional/effort_logs_controller_test.rb
@@ -406,3 +406,31 @@ def test_should_not_create_current_effort_log_with_new
   end
 
 end
+
+def test_should_not_update_old_effort_log_as_student
+  login_as :student_sam
+  put :update, :id => effort_logs(:week_one).id, :effort_log => { }
+  assert_equal('You are unable to update effort logs from the past.', flash[:error])
+  assert_response :redirect
+end
+
+def test_should_not_update_effort_log_as_another_student
+  login_as :student_john
+  put :update, :id => effort_logs(:this_week).id, :effort_log => { }
+  assert_equal('You do not have permission to edit the effort log.', flash[:error])
+  assert_response :redirect
+end
+
+def test_should_not_get_edit_previous
+  login_as :student_sam
+  get :edit, :id => effort_logs(:week_one).id
+  assert_equal('You are unable to update effort logs from the past.', flash[:error])
+  assert_response :redirect
+end
+
+def test_should_not_get_edit_current_as_another_student
+  login_as :student_john
+  get :edit, :id => effort_logs(:this_week).id
+  assert_equal('You do not have permission to edit the effort log.', flash[:error])
+  assert_response :redirect
+end


### PR DESCRIPTION
Fixes the following bug:

Incorrect error message.  Error does not always mean you cannot update effort log from past.  It can be that the user tries to edit another person's effort log and caused an error.
