### PR TITLE
Team Super8 - Trivial defect 15

### DIFF
--- a/app/controllers/effort_logs_controller.rb
+++ b/app/controllers/effort_logs_controller.rb
@@ -319,7 +319,7 @@ class EffortLogsController < ApplicationController
         course_error_msg = @effort_log.validate_effort_against_registered_courses()
         flash[:notice] = 'EffortLog was successfully updated.'
         if (course_error_msg!="")
-           flash[:error] = 'You are not on a team in the following course(s)<br/>' + course_error_msg
+           flash[:error] = 'You are either not on a team in, or not registered for the following course(s)<br/>' + course_error_msg
         end
         format.html { redirect_to(edit_effort_log_url) }
         format.xml  { head :ok }


### PR DESCRIPTION
Fix for the following bug:

Incorrect error message.  Error does not always mean person is not on a team, it means that user is not registered for the course
