### PR TITLE
Team Super8 - Trivial defect 16

### DIFF
--- a/app/controllers/effort_log_line_items_controller.rb
+++ b/app/controllers/effort_log_line_items_controller.rb
@@ -1,6 +1,9 @@
 class EffortLogLineItemsController < ApplicationController
   # GET /effort_log_line_items
   # GET /effort_log_line_items.xml
+
+  before_filter :redirect_to_effort_log_index
+
   def index
     @effort_log_line_items = EffortLogLineItem.find(:all)
 
@@ -82,5 +85,10 @@ class EffortLogLineItemsController < ApplicationController
       format.html { redirect_to(effort_log_line_items_url) }
       format.xml  { head :ok }
     end
+  end
+
+  protected
+  def redirect_to_effort_log_index
+    redirect_to :controller => :effort_logs, :action => :index
   end
 end

--- a/test/functional/effort_log_line_items_controller_test.rb
+++ b/test/functional/effort_log_line_items_controller_test.rb
@@ -1,45 +1,22 @@
 require 'test_helper'
 
 class EffortLogLineItemsControllerTest < ActionController::TestCase
-  def test_should_get_index
+  
+  def test_should_redirect_to_effort_log_index
     get :index
-    assert_response :success
-    assert_not_nil assigns(:effort_log_line_items)
-  end
-
-  def test_should_get_new
+    assert_redirected_to :controller => :effort_logs, :action => :index
     get :new
-    assert_response :success
-  end
-
-  def test_should_create_effort_log_line_item
-    assert_difference('EffortLogLineItem.count') do
-      post :create, :effort_log_line_item => { }
-    end
-
-    assert_redirected_to effort_log_line_item_path(assigns(:effort_log_line_item))
-  end
-
-  def test_should_show_effort_log_line_item
+    assert_redirected_to :controller => :effort_logs, :action => :index
     get :show, :id => effort_log_line_items(:one).id
-    assert_response :success
-  end
-
-  def test_should_get_edit
+    assert_redirected_to :controller => :effort_logs, :action => :index
     get :edit, :id => effort_log_line_items(:one).id
-    assert_response :success
-  end
-
-  def test_should_update_effort_log_line_item
+    assert_redirected_to :controller => :effort_logs, :action => :index
     put :update, :id => effort_log_line_items(:one).id, :effort_log_line_item => { }
-    assert_redirected_to effort_log_line_item_path(assigns(:effort_log_line_item))
-  end
-
-  def test_should_destroy_effort_log_line_item
-    assert_difference('EffortLogLineItem.count', -1) do
+    assert_redirected_to :controller => :effort_logs, :action => :index
+    assert_difference('EffortLogLineItem.count', 0) do
       delete :destroy, :id => effort_log_line_items(:one).id
+      assert_redirected_to :controller => :effort_logs, :action => :index
     end
-
-    assert_redirected_to effort_log_line_items_path
   end
+  
 end


### PR DESCRIPTION
Fixes the following bugs by hiding effort log line item views:
- Doesn't make sense to view effort log line items individually, outside of the full effort log.
- Can view and edit another user's effort logs if you find the right line items.
