### PR TITLE
Team Super8 - Trivial defect 24

### DIFF
--- a/app/views/effort_logs/_description_update.js.erb
+++ b/app/views/effort_logs/_description_update.js.erb
@@ -1,3 +1,3 @@
 <%  unless  @selected_type.nil? %>
-Defintion of <%= @selected_type.name%>: <%= @selected_type.description %>
+Definition of <%= @selected_type.name%>: <%= @selected_type.description %>
 <% end %>


### PR DESCRIPTION
Fixes the following bug:  "Definition" is spelled wrong
