### PR TITLE
Fix for slow-test-3

### DIFF
--- a/spec/requests/teams_spec.rb
+++ b/spec/requests/teams_spec.rb
@@ -26,6 +26,7 @@ describe "teams" do
     end
 
     it "shows correct teams" do
+      Team.any_instance.stub(:show_addresses_for_mailing_list).and_return(["email"])
       page.should have_link("#{@team.name}")
       page.should have_link("Show")
       click_link "Show"


### PR DESCRIPTION
Stubbed out the method that got the team member's emails from Google. Improved test speed from 1.4 to .3 seconds on my system.
