### PR TITLE
email-user-to-update-profile

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -339,16 +339,93 @@ class User < ActiveRecord::Base
 
 # attribute :github
 # If the user has not set this attribute, then ask the user to do so
-  def notify_about_missing_field(attribute, message)
-    if self.send(attribute).blank?
-      options = {:to => self.email,
-                 :subject => "Your user account needs updating",
-                 :message => message,
-                 :url_label => "Modify your profile",
-                 :url => Rails.application.routes.url_helpers.edit_user_url(self, :host => "rails.sv.cmu.edu")
-      }
-      GenericMailer.email(options).deliver
+  def notify_about_missing_field()
+    notification_fields = []
+    self.attributes.each do |key, val|
+      case key
+        when "first_name"
+          if val.nil? 
+            notification_fields << "Preferred First Name"
+          end
+        when "github"
+          if val.nil? 
+            notification_fields << "Github"
+          end
+        when "last_name"
+          if val.nil? 
+            notification_fields << "Last Name"
+          end
+        when "organization_name"
+          if val.nil? 
+            notification_fields << "Organization Company"
+          end
+        when "personal_email"
+          if val.nil? 
+            notification_fields << "Personal Email"
+          end
+        when "pronunciation"
+          if val.nil? 
+            notification_fields << "Pronunciation"
+          end
+        when "skype"
+          if val.nil? 
+            notification_fields << "Skype"
+          end
+        when "strength1_id"
+          if val.nil? 
+            notification_fields << "Strength 1"
+          end
+        when "strength2_id"
+          if val.nil? 
+            notification_fields << "Strength 2"
+          end
+        when "strength3_id"
+          if val.nil? 
+            notification_fields << "Strength 3"
+          end
+        when "strength4_id"
+          if val.nil? 
+            notification_fields << "Strength 4"
+          end
+        when "strength5_id"
+          if val.nil? 
+            notification_fields << "Strength 5"
+          end
+        when "telephone1"
+          if val.nil? 
+            notification_fields << "Telephone"
+          end
+        when "title"
+          if val.nil? 
+            notification_fields << "Organization Title"
+          end
+        when "work_city"
+          if val.nil? 
+            notification_fields << "Work City"
+          end
+        when "work_state"
+          if val.nil? 
+            notification_fields << "Work State"
+          end
+        when "work_country"
+          if val.nil? 
+            notification_fields << "Work Country"
+          end
+        when "user_text"
+          if val =~ /<p>I'd like to accomplish the following three goals (professional or personal) by the time I graduate:<\/p>/
+            notification_fields << "User Text"
+          end
+        when "biography"
+          if val =~ /sheepherders on the hills of BoingBoing/
+            notification_fields << "Biography"
+          end
+        when "local_near_remote"
+          if val == "Unknown" 
+            notification_fields << "Local Near Remote Status"
+          end
+      end
     end
+    notification_fields
   end
 
 

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -32,6 +32,12 @@ task :cron do
    puts "----done."
  end
 
+ if Date.today.day == 1 # run on the first on the month
+   puts "----Updating cmu:update_user_profile_email"
+   Rake::Task['cmu:update_user_profile_email'].invoke
+   puts "----done."
+ end
+
  if Date.today.day == 10 || Date.today.day == 15
    puts "----Send cmu:sponsored_projects email"
    Rake::Task['cmu:sponsored_projects:emails_staff_requesting_confirmation_for_allocations'].invoke

--- a/lib/tasks/send_partial_profile_email.rake
+++ b/lib/tasks/send_partial_profile_email.rake
@@ -1,0 +1,26 @@
+require 'rubygems'
+require 'rake'
+
+namespace :cmu do
+  desc "Do update_user_profile_email"
+  task(:update_user_profile_email => :environment) do
+    users = User.all
+    users.each do |user|
+      notification_fields = user.notify_about_missing_field
+      unless notification_fields.empty?
+        message = "The following fields from your profile need your attention: \n"
+        notification_fields.each do |val|
+          message += "#{val}\n"
+        end
+
+        options = {:to => user.email,
+                   :subject => "Your user profile needs updating",
+                   :message => message,
+                   :url_label => "Modify your profile",
+                   :url => Rails.application.routes.url_helpers.edit_user_url(user, :host => "rails.sv.cmu.edu")
+        }
+        GenericMailer.email(options).deliver
+      end
+    end
+  end
+end

--- a/spec/mailers/update_user_profile_mailer_spec.rb
+++ b/spec/mailers/update_user_profile_mailer_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require "rake"
+
+describe "User Profile Update Mailer" do
+  before(:each) do
+    ActionMailer::Base.delivery_method = :test
+    ActionMailer::Base.perform_deliveries = true
+    ActionMailer::Base.deliveries = []
+  end
+
+
+  it "should send a user an email if they have fields that need updating" do
+    student_sam = FactoryGirl.create(:student_sam)
+
+
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake.application.rake_require "tasks/send_partial_profile_email"
+    Rake::Task.define_task(:environment)
+    @rake['cmu:update_user_profile_email'].invoke  
+
+    ActionMailer::Base.deliveries.first.to.first.should == student_sam.email
+    ActionMailer::Base.deliveries.first.parts.find {|p| p.content_type.match /html/}.body.raw_source.should =~ /Github
+Organization Company
+Personal Email
+Pronunciation
+Skype
+Strength 1
+Strength 2
+Strength 3
+Strength 4
+Strength 5
+Telephone
+Organization Title
+Work City
+Work Country
+Work State/
+
+    ActionMailer::Base.deliveries.size.should == 1
+  end
+end


### PR DESCRIPTION
Todd,

We added in a rake task that can be called via cron which will
iterate through all of the users and check the fields in their
profile to see if they need updating, and then send that user an email
that lists the fields that they need to update.

We set this to run via cron once a month on the first of the month.

Authors:
Craig Hokanson
Tim Zaitsev
James Ricks
