### PR TITLE
Team Number Crunchers - Defect 17 Fixed

### DIFF
--- a/app/views/page_comments/edit.html.erb
+++ b/app/views/page_comments/edit.html.erb
@@ -26,7 +26,7 @@
     </p>
     <p>
       <%= f.label :type %><br/>
-      <%= f.collection_select(:curriculum_comment_type_id, @types, :id, :name) %>
+      <%= f.collection_select(:page_comment_type_id, @types, :id, :name) %>
     </p>
     <p>
       <%= f.label :notify_me, "Email me if other people add comments to the same page" %>

--- a/spec/views/page_comments/edit.html.erb_spec.rb
+++ b/spec/views/page_comments/edit.html.erb_spec.rb
@@ -1,0 +1,10 @@
+require "rspec"
+
+describe "My behaviour" do
+
+  it "should do something" do
+
+    #To change this template use File | Settings | File Templates.
+    true.should == false
+  end
+end


### PR DESCRIPTION
Fixed an error with page_comments.  Page comments were using a curriculum_type instead of the page_comment_type
