### PR TITLE
Add NFS options to Vagrantfile and vagrant instructions.

### DIFF
--- a/CMUSV_VM_Ubuntu.md
+++ b/CMUSV_VM_Ubuntu.md
@@ -137,7 +137,7 @@ This document lists down the steps to get the Ruby on Rails project (cmusv) up a
         vagrant ssh
         cd /vagrant
         sudo apt-get upgrade
-        sudo apt-get install build-essential zlib1g-dev curl git-core sqlite3 libsqlite3-dev
+        sudo apt-get install build-essential zlib1g-dev curl git-core sqlite3 libsqlite3-dev nfs-kernel-server
 
 9. install ruby
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant::Config.run do |config|
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
-  # config.vm.network :hostonly, "192.168.33.10"
+  config.vm.network :hostonly, "192.168.33.10"
 
 
   # Assign this VM to a bridged network, allowing you to connect directly to a
@@ -37,7 +37,7 @@ Vagrant::Config.run do |config|
   # an identifier, the second is the path on the guest to mount the
   # folder, and the third is the path on the host to the actual folder.
   # config.vm.share_folder "v-data", "/vagrant_data", "../data"
-  # config.vm.share_folder("v-root", "/vagrant", ".", :nfs => true)
+  config.vm.share_folder("vagrant-root", "/vagrant", ".", :nfs => true)
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.


### PR DESCRIPTION
Using Vagrant slows down running the rails server, and running rspec. I found instructions in a blog post (http://kubaf.wordpress.com/2013/01/12/vagrant-speed-up-on-mac-os-x/) about how to speed things up using NFS. I applied that and the speed was much better (10 sec vs. 2 sec for the same page load). This pull request will make NFS work "right out of the box".
