### PR TITLE
Fix: Assignment reorder

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -115,7 +115,7 @@ class AssignmentsController < ApplicationController
   def show
     @no_pad = true
     @assignments = @course.assignments
-    authorize! :read, @course
+    authorize! :reorder_assignments, @course
 
     respond_to do |format|
       format.html # showml.erb

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -61,7 +61,7 @@ class Ability
     end
 
     if  (user.is_staff?)
-      can [:teach, :create, :update, :peer_evaluation, :team_formation], Course
+      can [:teach, :create, :update, :peer_evaluation, :team_formation, :reorder_assignments], Course
       can :manage, Assignment
       can [:create, :see_job_details], Job
     end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -146,5 +146,17 @@ describe AssignmentsController do
     end
   end
 
+  describe "GET show" do
+    before do
+      get :show, :course_id => @course
+    end
+    it "renders the 'show' template" do
+      response.should render_template("show")
+    end
+    it "assigns all assignments as @assignments" do
+      assignments = @course.assignments
+      assigns(:assignments).should eq(assignments)
+    end
+  end
 
 end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -159,4 +159,23 @@ describe AssignmentsController do
     end
   end
 
+  describe "POST reposition" do
+    it "reorders the assignments" do
+      FactoryGirl.create(:assignment, course: @course)
+      FactoryGirl.create(:assignment, course: @course)
+      
+      # Generate an array of the assignment ids in order and reversed
+      assignment_ids = @course.assignments.map { |assignment| assignment.id }
+      reversed_assignment_ids = assignment_ids.reverse
+      
+      # POST the reversed ids and reload the course to obtain updated assignment order
+      post :reposition, :course_id => @course, :assignment => reversed_assignment_ids
+      @course.reload
+      updated_assignment_ids = @course.assignments.map { |assignment| assignment.id }
+
+      updated_assignment_ids.should_not eq(assignment_ids)
+      updated_assignment_ids.should eq(reversed_assignment_ids)
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes permissions to give faculty the ability to reorder assignments. The `read` permission was consolidated into the `reorder_assignments` permission, since the `assignment` `show` view is used only to reorder assignments.

Similar to #266, but adds a few more tests.

MFSE Spring 2014 Team Complexity
