### PR TITLE
A few wording adjustments on the welcome email.

### DIFF
--- a/app/views/person_mailer/welcome_email.html.erb
+++ b/app/views/person_mailer/welcome_email.html.erb
@@ -2,10 +2,9 @@
 <p/>
 This message contains important information regarding your CMU Silicon Valley email account.
 <p/>
-It is a copy (perhaps outdated) of the information at
-<a href="http://www.cmu.edu/silicon-valley/information/technology/index.html">http://www.cmu.edu/silicon-valley/information/technology/index.html</a>, except personalized.
-<p/>
 Please read, complete your email set-up, and save this message for future reference.
+(The information below is also available at
+<a href="http://www.cmu.edu/silicon-valley/information/technology/index.html">http://www.cmu.edu/silicon-valley/information/technology/index.html</a>.)
 <p/>
 We ask all community members to check their CMU-SV email every business day because Silicon Valley academic and administrative communications are sent there.
 <p/>
@@ -27,8 +26,8 @@ Set Up Your Gmail Messages To Be From:  <%= @person.email %>
 </b>
 <ol>
   <li>
-    Log into your CMU-SV Gmail account at <a href="http://gmail.sv.cmu.edu/">http://gmail.sv.cmu.edu/</a>
-(a <a href="https://mail.google.com/a/west.cmu.edu/">re-direct</a>).
+    Log into your CMU-SV Gmail account at <a href="http://gmail.sv.cmu.edu/">http://gmail.sv.cmu.edu/</a>.
+(If that does not work, try <a href="https://mail.google.com/a/west.cmu.edu/">this link</a>.)
   </li>
     <ul>
       <li>

--- a/app/views/person_mailer/welcome_email.html.erb
+++ b/app/views/person_mailer/welcome_email.html.erb
@@ -2,6 +2,9 @@
 <p/>
 This message contains important information regarding your CMU Silicon Valley email account.
 <p/>
+It is a copy (perhaps outdated) of the information at
+<a href="http://www.cmu.edu/silicon-valley/information/technology/index.html">http://www.cmu.edu/silicon-valley/information/technology/index.html</a>, except personalized.
+<p/>
 Please read, complete your email set-up, and save this message for future reference.
 <p/>
 We ask all community members to check their CMU-SV email every business day because Silicon Valley academic and administrative communications are sent there.
@@ -24,7 +27,8 @@ Set Up Your Gmail Messages To Be From:  <%= @person.email %>
 </b>
 <ol>
   <li>
-    Log into your CMU-SV Gmail account at <a href="http://gmail.sv.cmu.edu/">http://gmail.sv.cmu.edu/</a>.
+    Log into your CMU-SV Gmail account at <a href="http://gmail.sv.cmu.edu/">http://gmail.sv.cmu.edu/</a>
+(a <a href="https://mail.google.com/a/west.cmu.edu/">re-direct</a>).
   </li>
     <ul>
       <li>
@@ -47,10 +51,6 @@ Set Up Your Gmail Messages To Be From:  <%= @person.email %>
     For "Email address", use:  <%= @person.email %>
   </li><li>
     Uncheck the "Treat as an alias" checkbox.
-  </li><li>
-    Click "Next Step".
-  </li><li>
-    Keep the selected radio button to "Send through Carnegie Mellon Silicon Valley Mail".
   </li><li>
     Click "Next Step".
   </li><li>


### PR DESCRIPTION
Added at top pointer to live, generic version of the included info (which is personalized).

Added the actual re-direct in case gmail.sv.cmu.edu does not.
Deleted extraneous step in setting up email as from @sv.cmu.edu.